### PR TITLE
Adding arguments in output of deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "chai": "^4.3.4",
     "dotenv": "^10.0.0",
     "ethereum-waffle": "^3.4.0",
+    "ethereumjs-abi": "^0.6.8",
     "ethers": "^5.5.2",
     "ethlint": "^1.2.5",
     "fs-extra": "^10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ specifiers:
   chai: ^4.3.4
   dotenv: ^10.0.0
   ethereum-waffle: ^3.4.0
+  ethereumjs-abi: ^0.6.8
   ethers: ^5.5.2
   ethlint: ^1.2.5
   fs-extra: ^10.0.0
@@ -38,6 +39,7 @@ devDependencies:
   chai: 4.3.4
   dotenv: 10.0.0
   ethereum-waffle: 3.4.0_typescript@4.6.2
+  ethereumjs-abi: 0.6.8
   ethers: 5.5.2
   ethlint: 1.2.5_solium@1.2.5
   fs-extra: 10.0.0

--- a/scripts/deploy-seedfactory.js
+++ b/scripts/deploy-seedfactory.js
@@ -32,6 +32,10 @@ async function main() {
 
   console.log(`
 To verify SeedFactory source code, flatten the source code, get the implementation address in .openzeppelin, remove the licenses, except the first one, and verify manually
+
+The encoded arguments are:
+
+${deployUtils.encodeArguments(["address"], [seedAddress])}
 `);
 
   console.log("SeedFactory deployed at", seedFactory.address);

--- a/scripts/deploy-synrpool.js
+++ b/scripts/deploy-synrpool.js
@@ -37,6 +37,11 @@ async function main() {
 
   console.log(`
 To verify SynrPool source code, flatten the source code, get the implementation address in .openzeppelin, remove the licenses, except the first one, and verify manually
+
+The encoded arguments are:
+
+${deployUtils.encodeArguments(["address", "address"], [synrAddress, sSynrAddress])}
+
 `);
 
   console.log("SynrPool deployed at", synrPool.address);

--- a/scripts/lib/DeployUtils.js
+++ b/scripts/lib/DeployUtils.js
@@ -1,6 +1,7 @@
 const path = require("path");
 const fs = require("fs-extra");
 const {Contract} = require("@ethersproject/contracts");
+const abi = require('ethereumjs-abi')
 
 class DeployUtils {
   constructor(ethers) {
@@ -81,6 +82,10 @@ class DeployUtils {
     }
     // console.log(deployed)
     await fs.writeFile(deployedJson, JSON.stringify(deployed, null, 2));
+  }
+
+  encodeArguments(parameterTypes, parameterValues) {
+    return abi.rawEncode(parameterTypes, parameterValues).toString('hex');
   }
 }
 


### PR DESCRIPTION
I integrated a function to print the encoded arguments during the deployment of SynrPool and SeedFactory