### PR TITLE
Fix stake for weed

### DIFF
--- a/contracts/interfaces/ISidePool.sol
+++ b/contracts/interfaces/ISidePool.sol
@@ -55,6 +55,9 @@ interface ISidePool {
     uint16 swapFactor;
     uint16 stakeFactor;
     uint16 taxPoints; // ex 250 = 2.5%
+    uint16 burnRatio;
+    uint16 priceRatio;
+    uint8 coolDownDays; // cool down period for
   }
 
   struct NftConf {
@@ -71,7 +74,10 @@ interface ISidePool {
     uint16 decayFactor_,
     uint16 swapFactor_,
     uint16 stakeFactor_,
-    uint16 taxPoints_
+    uint16 taxPoints_,
+    uint16 burnRatio_,
+    uint16 priceRatio_,
+    uint8 coolDownDays_
   ) external;
 
   function updateConf(
@@ -79,7 +85,10 @@ interface ISidePool {
     uint16 decayFactor_,
     uint16 swapFactor_,
     uint16 stakeFactor_,
-    uint16 taxPoints_
+    uint16 taxPoints_,
+    uint16 burnRatio_,
+    uint16 priceRatio_,
+    uint8 coolDownDays_
   ) external;
 
   // Split configuration in two struct to avoid following error calling initPool

--- a/contracts/pool/Constants.sol
+++ b/contracts/pool/Constants.sol
@@ -10,5 +10,5 @@ contract Constants {
   uint8 public constant SYNR_PASS_STAKE_FOR_BOOST = 2;
   uint8 public constant SYNR_PASS_STAKE_FOR_SEEDS = 3;
   uint8 public constant BLUEPRINT_STAKE_FOR_BOOST = 4;
-  uint8 public constant SEED_STAKE = 5;
+  uint8 public constant SEED_SWAP = 5;
 }

--- a/contracts/pool/FarmingPool.sol
+++ b/contracts/pool/FarmingPool.sol
@@ -36,7 +36,7 @@ contract FarmingPool is SidePool {
     uint256 tokenAmountOrID
   ) external virtual override {
     // mainIndex = type(uint16).max means no meanIndex
-    require(tokenType == BLUEPRINT_STAKE_FOR_BOOST || tokenType == SEED_STAKE, "FarmingPool: unsupported token");
+    require(tokenType == BLUEPRINT_STAKE_FOR_BOOST || tokenType == SEED_SWAP, "FarmingPool: unsupported token");
     _stake(
       _msgSender(),
       tokenType,
@@ -54,7 +54,7 @@ contract FarmingPool is SidePool {
   function unstake(uint256 depositIndex) external override {
     Deposit memory deposit = users[_msgSender()].deposits[depositIndex];
     require(
-      deposit.tokenType == SEED_STAKE || deposit.tokenType == BLUEPRINT_STAKE_FOR_BOOST,
+      deposit.tokenType == SEED_SWAP || deposit.tokenType == BLUEPRINT_STAKE_FOR_BOOST,
       "FarmingPool: invalid tokenType"
     );
     _unstakeDeposit(deposit);

--- a/contracts/pool/FarmingPool.sol
+++ b/contracts/pool/FarmingPool.sol
@@ -53,10 +53,7 @@ contract FarmingPool is SidePool {
    */
   function unstake(uint256 depositIndex) external override {
     Deposit memory deposit = users[_msgSender()].deposits[depositIndex];
-    require(
-      deposit.tokenType == SEED_SWAP || deposit.tokenType == BLUEPRINT_STAKE_FOR_BOOST,
-      "FarmingPool: invalid tokenType"
-    );
+    require(deposit.tokenType == BLUEPRINT_STAKE_FOR_BOOST, "FarmingPool: only bluprints can be unstaked");
     _unstakeDeposit(deposit);
   }
 

--- a/contracts/pool/SidePool.sol
+++ b/contracts/pool/SidePool.sol
@@ -347,7 +347,7 @@ contract SidePool is Constants, PayloadUtils, ISidePool, TokenReceiver, Initiali
       users[user_].blueprintsAmount++;
       // SidePool must be approve to spend blueprints
       blueprint.safeTransferFrom(user_, address(this), tokenAmountOrID);
-    } else if (tokenType == SEED_STAKE) {
+    } else if (tokenType == SEED_SWAP) {
       tokenAmount = tokenAmountOrID;
       // SidePool must be approve to spend SEED
       stakedToken.transferFrom(user_, address(this), tokenAmount);
@@ -473,7 +473,7 @@ contract SidePool is Constants, PayloadUtils, ISidePool, TokenReceiver, Initiali
         uint256(deposit.tokenAmountOrID) == tokenAmountOrID,
       "SidePool: inconsistent deposit"
     );
-    if (tokenType == SYNR_STAKE || tokenType == SEED_STAKE) {
+    if (tokenType == SYNR_STAKE || tokenType == SEED_SWAP) {
       uint256 vestedPercentage = getVestedPercentage(
         block.timestamp,
         uint256(deposit.lockedFrom),

--- a/contracts/pool/SidePool.sol
+++ b/contracts/pool/SidePool.sol
@@ -61,7 +61,10 @@ contract SidePool is Constants, PayloadUtils, ISidePool, TokenReceiver, Initiali
     uint16 decayFactor_,
     uint16 swapFactor_,
     uint16 stakeFactor_,
-    uint16 taxPoints_
+    uint16 taxPoints_,
+    uint16 burnRatio_,
+    uint16 priceRatio_,
+    uint8 coolDownDays_
   ) external override onlyOwner {
     require(conf.maximumLockupTime == 0, "SidePool: already initiated");
     conf = Conf({
@@ -73,7 +76,10 @@ contract SidePool is Constants, PayloadUtils, ISidePool, TokenReceiver, Initiali
       lastRatioUpdateAt: uint32(block.timestamp),
       swapFactor: swapFactor_,
       stakeFactor: stakeFactor_,
-      taxPoints: taxPoints_
+      taxPoints: taxPoints_,
+      burnRatio: burnRatio_,
+      priceRatio: priceRatio_,
+    coolDownDays: coolDownDays_
     });
   }
 
@@ -83,7 +89,10 @@ contract SidePool is Constants, PayloadUtils, ISidePool, TokenReceiver, Initiali
     uint16 decayFactor_,
     uint16 swapFactor_,
     uint16 stakeFactor_,
-    uint16 taxPoints_
+    uint16 taxPoints_,
+    uint16 burnRatio_,
+    uint16 priceRatio_,
+    uint8 coolDownDays_
   ) external override onlyOwner {
     require(conf.maximumLockupTime > 0, "SidePool: not initiated yet");
     if (decayInterval_ > 0) {
@@ -100,6 +109,15 @@ contract SidePool is Constants, PayloadUtils, ISidePool, TokenReceiver, Initiali
     }
     if (taxPoints_ > 0) {
       conf.taxPoints = taxPoints_;
+    }
+    if (burnRatio_ > 0) {
+      conf.burnRatio = burnRatio_;
+    }
+    if (priceRatio_ > 0) {
+      conf.priceRatio = priceRatio_;
+    }
+    if (coolDownDays_ > 0) {
+      conf.coolDownDays = coolDownDays_;
     }
   }
 
@@ -333,15 +351,15 @@ contract SidePool is Constants, PayloadUtils, ISidePool, TokenReceiver, Initiali
     _collectRewards(user_);
     uint256 tokenAmount;
     if (tokenType == S_SYNR_SWAP) {
-      tokenAmount = tokenAmountOrID.mul(conf.swapFactor);
+      tokenAmount = tokenAmountOrID.mul(conf.swapFactor).mul(conf.priceRatio).div(10000);
       stakedToken.mint(address(this), tokenAmount);
     } else if (tokenType == SYNR_STAKE) {
-      tokenAmount = tokenAmountOrID.mul(conf.stakeFactor);
+      tokenAmount = tokenAmountOrID.mul(conf.stakeFactor).mul(conf.priceRatio).div(10000);
       stakedToken.mint(address(this), tokenAmount);
     } else if (tokenType == SYNR_PASS_STAKE_FOR_BOOST) {
       users[user_].passAmount++;
     } else if (tokenType == SYNR_PASS_STAKE_FOR_SEEDS) {
-      tokenAmount = uint256(nftConf.synrEquivalent).mul(conf.stakeFactor);
+      tokenAmount = uint256(nftConf.synrEquivalent).mul(conf.stakeFactor).mul(conf.priceRatio).div(10000);
       stakedToken.mint(address(this), tokenAmount);
     } else if (tokenType == BLUEPRINT_STAKE_FOR_BOOST) {
       users[user_].blueprintsAmount++;
@@ -351,13 +369,15 @@ contract SidePool is Constants, PayloadUtils, ISidePool, TokenReceiver, Initiali
       tokenAmount = tokenAmountOrID;
       // SidePool must be approve to spend SEED
       stakedToken.transferFrom(user_, address(this), tokenAmount);
+      taxes += tokenAmount;
+      stakedToken.burnFrom(address(this), tokenAmount.mul(conf.burnRatio).div(10000));
     } else {
       revert("SidePool: invalid tokenType");
     }
     users[user_].tokenAmount = uint96(uint256(users[user_].tokenAmount).add(tokenAmount));
     // add deposit
-    if (tokenType == 0) {
-      lockedUntil = lockedFrom + conf.decayInterval;
+    if (tokenType == S_SYNR_SWAP || tokenType == SEED_SWAP) {
+      lockedUntil = lockedFrom + uint(conf.coolDownDays).mul(1 days);
     }
     uint256 index = users[user_].deposits.length;
     Deposit memory deposit = Deposit({

--- a/contracts/pool/SidePool.sol
+++ b/contracts/pool/SidePool.sol
@@ -370,7 +370,7 @@ contract SidePool is Constants, PayloadUtils, ISidePool, TokenReceiver, Initiali
       // SidePool must be approve to spend SEED
       stakedToken.transferFrom(user_, address(this), tokenAmount);
       taxes += tokenAmount;
-      stakedToken.burnFrom(address(this), tokenAmount.mul(conf.burnRatio).div(10000));
+      stakedToken.burn(tokenAmount.mul(conf.burnRatio).div(10000));
     } else {
       revert("SidePool: invalid tokenType");
     }

--- a/contracts/token/SideToken.sol
+++ b/contracts/token/SideToken.sol
@@ -2,11 +2,11 @@
 pragma solidity ^0.8.4;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 import "@openzeppelin/contracts/access/AccessControl.sol";
 
-contract SideToken is ERC20, AccessControl {
+contract SideToken is ERC20, ERC20Burnable, AccessControl {
   bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
-  bytes32 public constant BURNER_ROLE = keccak256("BURNER_ROLE");
 
   constructor(string memory name, string memory symbol) ERC20(name, symbol) {
     _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
@@ -20,11 +20,4 @@ contract SideToken is ERC20, AccessControl {
     _mint(to, amount);
   }
 
-  /**
-   * @param from address to mint the token.
-   * @param amount amount to be minted.
-   */
-  function burnFrom(address from, uint256 amount) public onlyRole(BURNER_ROLE) {
-    _burn(from, amount);
-  }
 }

--- a/contracts/token/SideToken.sol
+++ b/contracts/token/SideToken.sol
@@ -6,18 +6,25 @@ import "@openzeppelin/contracts/access/AccessControl.sol";
 
 contract SideToken is ERC20, AccessControl {
   bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
+  bytes32 public constant BURNER_ROLE = keccak256("BURNER_ROLE");
 
   constructor(string memory name, string memory symbol) ERC20(name, symbol) {
     _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
-    _grantRole(MINTER_ROLE, msg.sender);
   }
 
   /**
-   *
    * @param to address to mint the token.
    * @param amount amount to be minted.
    */
   function mint(address to, uint256 amount) public onlyRole(MINTER_ROLE) {
     _mint(to, amount);
+  }
+
+  /**
+   * @param from address to mint the token.
+   * @param amount amount to be minted.
+   */
+  function burnFrom(address from, uint256 amount) public onlyRole(BURNER_ROLE) {
+    _burn(from, amount);
   }
 }

--- a/test/FarmingPool.test.js
+++ b/test/FarmingPool.test.js
@@ -53,7 +53,7 @@ describe("#FarmingPool", function () {
     await pool.deployed();
 
     if (initPool) {
-      await pool.initPool(1000, week, 9800, 1000, 100, 800);
+      await pool.initPool(1000, week, 9800, 1000, 100, 800, 3000, 10000, 10);
       await pool.updateNftConf(
         0,
         0,
@@ -64,6 +64,7 @@ describe("#FarmingPool", function () {
     }
 
     await seed.grantRole(await seed.MINTER_ROLE(), deployer.address);
+    await seed.grantRole(await seed.BURNER_ROLE(), pool.address);
     await seed.mint(user0.address, ethers.utils.parseEther(user0sSeeds));
 
     await weed.grantRole(await weed.MINTER_ROLE(), pool.address);
@@ -77,14 +78,14 @@ describe("#FarmingPool", function () {
     });
 
     it("should revert if already initiated", async function () {
-      await pool.initPool(1000, week, 9800, 1000, 100, 800);
-      expect(pool.initPool(1000, week, 9800, 1000, 100, 1000)).revertedWith("SidePool: already initiated");
+      await pool.initPool(1000, week, 9800, 1000, 100, 800, 3000, 10000, 10);
+      expect(pool.initPool(1000, week, 9800, 1000, 100, 1000, 3000, 10000, 10)).revertedWith("SidePool: already initiated");
     });
 
     it("should revert if wrong parameters", async function () {
-      await assertThrowsMessage(pool.initPool(1000, week, 129800, 1000, 100, 800), "value out-of-bounds");
-      await assertThrowsMessage(pool.initPool(1000, 1e12, 9800, 1000, 100, 800), "value out-of-bounds");
-      await assertThrowsMessage(pool.initPool(1e10, week, 9800, 1000, 100, 800), "value out-of-bounds");
+      await assertThrowsMessage(pool.initPool(1000, week, 129800, 1000, 100, 800, 3000, 10000, 10), "value out-of-bounds");
+      await assertThrowsMessage(pool.initPool(1000, 1e12, 9800, 1000, 100, 800, 3000, 10000, 10), "value out-of-bounds");
+      await assertThrowsMessage(pool.initPool(1e10, week, 9800, 1000, 100, 800, 3000, 10000, 10), "value out-of-bounds");
     });
   });
 
@@ -201,8 +202,8 @@ describe("#FarmingPool", function () {
       const balanceBefore = await seed.balanceOf(user0.address);
       expect(balanceBefore).equal(normalize(user0sSeeds));
 
-      const lockedUntil = (await getTimestamp()) + 1 + 24 * 3600 * 365;
-      expect(await pool.connect(user0).stake(SEED_SWAP, 365, amount))
+      const lockedUntil = (await getTimestamp()) + 1 + 24 * 3600 * 10;
+      expect(await pool.connect(user0).stake(SEED_SWAP, 0, amount))
         .emit(pool, "DepositSaved")
         .withArgs(user0.address, 0);
 

--- a/test/FarmingPool.test.js
+++ b/test/FarmingPool.test.js
@@ -64,7 +64,6 @@ describe("#FarmingPool", function () {
     }
 
     await seed.grantRole(await seed.MINTER_ROLE(), deployer.address);
-    await seed.grantRole(await seed.BURNER_ROLE(), pool.address);
     await seed.mint(user0.address, ethers.utils.parseEther(user0sSeeds));
 
     await weed.grantRole(await weed.MINTER_ROLE(), pool.address);

--- a/test/FarmingPool.test.js
+++ b/test/FarmingPool.test.js
@@ -6,7 +6,7 @@ const {
   getTimestamp,
   increaseBlockTimestampBy,
   bytes32Address,
-  SEED_STAKE,
+  SEED_SWAP,
 } = require("./helpers");
 const {upgrades} = require("hardhat");
 
@@ -96,7 +96,7 @@ describe("#FarmingPool", function () {
       const lockedFrom = await getTimestamp();
       const lockedUntil = lockedFrom + 3600 * 24 * 180;
       deposit = {
-        tokenType: SEED_STAKE,
+        tokenType: SEED_SWAP,
         lockedFrom,
         lockedUntil,
         tokenAmountOrID: amount,
@@ -147,7 +147,7 @@ describe("#FarmingPool", function () {
       const lockedFrom = await getTimestamp();
       const lockedUntil = lockedFrom + 3600 * 24 * 180;
       deposit = {
-        tokenType: SEED_STAKE,
+        tokenType: SEED_SWAP,
         lockedFrom,
         lockedUntil,
         tokenAmountOrID: amount,
@@ -202,13 +202,13 @@ describe("#FarmingPool", function () {
       expect(balanceBefore).equal(normalize(user0sSeeds));
 
       const lockedUntil = (await getTimestamp()) + 1 + 24 * 3600 * 365;
-      expect(await pool.connect(user0).stake(SEED_STAKE, 365, amount))
+      expect(await pool.connect(user0).stake(SEED_SWAP, 365, amount))
         .emit(pool, "DepositSaved")
         .withArgs(user0.address, 0);
 
       let deposit = await pool.getDepositByIndex(user0.address, 0);
       expect(deposit.tokenAmountOrID).equal(amount);
-      expect(deposit.tokenType).equal(SEED_STAKE);
+      expect(deposit.tokenType).equal(SEED_SWAP);
       expect(deposit.lockedUntil).equal(lockedUntil);
     });
   });

--- a/test/Integration.test.js
+++ b/test/Integration.test.js
@@ -97,7 +97,7 @@ describe("#Integration test", function () {
 
     seedPool = await upgrades.deployProxy(SeedPool, [seed.address, seed.address, blueprint.address]);
     await seedPool.deployed();
-    await seedPool.initPool(1000, 7 * 24 * 3600, 9800, 1000, 100, 800);
+    await seedPool.initPool(1000, 7 * 24 * 3600, 9800, 1000, 100, 800, 3000, 10000, 10);
     await seedPool.updateNftConf(100000, 1500, 500000, 150, 1000);
 
     seedFactory = await upgrades.deployProxy(SeedFactory, [seedPool.address]);

--- a/test/SidePool.test.js
+++ b/test/SidePool.test.js
@@ -47,7 +47,7 @@ describe("#SidePool", function () {
     await sidePool.deployed();
 
     if (initPool) {
-      await sidePool.initPool(1000, week, 9800, 1000, 100, 800);
+      await sidePool.initPool(1000, week, 9800, 1000, 100, 800, 3000, 10000, 10);
       await sidePool.updateNftConf(100000, 1500, 120000, 150, 1000);
     }
   }
@@ -60,14 +60,15 @@ describe("#SidePool", function () {
     });
 
     it("should revert if already initiated", async function () {
-      await sidePool.initPool(1000, week, 9800, 1000, 100, 800);
-      expect(sidePool.initPool(1000, week, 9800, 1000, 100, 1000)).revertedWith("SidePool: already initiated");
+      await sidePool.initPool(1000, week, 9800, 1000, 100, 800, 3000, 10000, 10);
+      expect(sidePool.initPool(1000, week, 9800, 1000, 100, 1000, 3000, 10000, 10)).revertedWith("SidePool: already initiated");
     });
 
     it("should revert if wrong parameters", async function () {
-      await assertThrowsMessage(sidePool.initPool(1000, week, 129800, 1000, 100, 800), "value out-of-bounds");
-      await assertThrowsMessage(sidePool.initPool(1000, 1e12, 9800, 1000, 100, 800), "value out-of-bounds");
-      await assertThrowsMessage(sidePool.initPool(1e10, week, 9800, 1000, 100, 800), "value out-of-bounds");
+      await assertThrowsMessage(sidePool.initPool(1000, week, 129800, 1000, 100, 800, 3000, 10000, 10), "value out-of-bounds");
+      await assertThrowsMessage(sidePool.initPool(1000, 1e12, 9800, 1000, 100, 800, 3000, 10000, 10), "value out-of-bounds");
+      await assertThrowsMessage(sidePool.initPool(1e10, week, 9800, 1000, 100, 800, 3000, 10000, 10), "value out-of-bounds");
+      await assertThrowsMessage(sidePool.initPool(1000, week, 9800, 1000, 100, 800, 233000, 10000, 10), "value out-of-bounds");
     });
   });
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -51,6 +51,6 @@ Helpers.SYNR_STAKE = 1;
 Helpers.SYNR_PASS_STAKE_FOR_BOOST = 2;
 Helpers.SYNR_PASS_STAKE_FOR_SEEDS = 3;
 Helpers.BLUEPRINT_STAKE_FOR_BOOST = 4;
-Helpers.SEED_STAKE = 5;
+Helpers.SEED_SWAP = 5;
 
 module.exports = Helpers;


### PR DESCRIPTION
This changes the swap Seed > Weed in a way similar to sSynr > Seed.
Also adds a burn to the Seed before getting the rest as tax.
Finally, it sets up a priceRatio to balance the price ratio between staked token and rewards token (needed only in the SeedFarmingPool).