### PR TITLE
Fix the risk that a transfer is reused to get more rewards

### DIFF
--- a/contracts/interfaces/ISidePool.sol
+++ b/contracts/interfaces/ISidePool.sol
@@ -90,13 +90,9 @@ interface ISidePool {
     uint8 coolDownDays_
   ) external;
 
-  function updatePriceRatio(
-    uint16 priceRatio_
-  ) external;
+  function updatePriceRatio(uint16 priceRatio_) external;
 
-  function updateOracle(
-    address oracle_
-  ) external;
+  function updateOracle(address oracle_) external;
 
   function pausePool(bool paused) external;
 
@@ -137,7 +133,7 @@ interface ISidePool {
 
   function canUnstakeWithoutTax(address user, uint256 mainIndex) external view returns (bool);
 
-  function getDepositIndexByMainIndex(address user, uint256 mainIndex) external view returns (uint256);
+  function getDepositIndexByMainIndex(address user, uint256 mainIndex) external view returns (uint256, bool);
 
   function getVestedPercentage(
     uint256 when,


### PR DESCRIPTION
Wormhole does not allow to set up an EVM as used. So, this little fix avoids that the users can launch WormholeCompleteTransfer many times to multi-spend their stakes.