### PR TITLE
Fix taxes amount

### DIFF
--- a/contracts/pool/SidePool.sol
+++ b/contracts/pool/SidePool.sol
@@ -394,7 +394,7 @@ contract SidePool is PayloadUtils, ISidePool, TokenReceiver, Initializable, Owna
       tokenAmount = tokenAmountOrID;
       // SidePool must be approve to spend SEED
       stakedToken.transferFrom(user_, address(this), tokenAmount);
-      taxes += tokenAmount;
+      taxes += tokenAmount.sub(tokenAmount.mul(conf.burnRatio).div(10000));
       stakedToken.burn(tokenAmount.mul(conf.burnRatio).div(10000));
     } else {
       revert("SidePool: invalid tokenType");


### PR DESCRIPTION
**DO NOT MERGE until CertiK is fine with it.**

This PR fixes a bug in the taxes calculated during a stake of type SEED_SWAP on the SidePool. In fact, the taxes was calculated as
```
      taxes += tokenAmount;
      stakedToken.burn(tokenAmount.mul(conf.burnRatio).div(10000));

```
This is wrong because the actual amount remaining after the following burning is lower. The correct calculation is:
```
      taxes += tokenAmount.sub(tokenAmount.mul(conf.burnRatio).div(10000));
      stakedToken.burn(tokenAmount.mul(conf.burnRatio).div(10000));
```
