### PR TITLE
Fix issue with passAmount

### DIFF
--- a/contracts/interfaces/ISidePool.sol
+++ b/contracts/interfaces/ISidePool.sol
@@ -124,6 +124,8 @@ interface ISidePool {
 
   function calculateTaxOnRewards(uint256 rewards) external view returns (uint256);
 
+  function passForBoostAmount(address user) external view returns (uint256);
+
   function boostWeight(address user_) external view returns (uint256);
 
   function collectRewards() external;


### PR DESCRIPTION
Fix issue with passAmount. Calculating the boost, SYNR Pass were used regardless of if they were staked for boost or for SYNR equivalent.