### PR TITLE
Fix pass amount

### DIFF
--- a/contracts/interfaces/ISidePool.sol
+++ b/contracts/interfaces/ISidePool.sol
@@ -124,6 +124,8 @@ interface ISidePool {
 
   function calculateTaxOnRewards(uint256 rewards) external view returns (uint256);
 
+  function passForBoostAmount(address user) external view returns (uint256);
+
   function boostWeight(address user_) external view returns (uint256);
 
   function collectRewards() external;


### PR DESCRIPTION
DO NOT MERGE until CrediK approves it.

Fix issue with passAmount.
The function that calculates the boost weight was accounting SYNR Pass, regardless of if they were staked for boost or for SYNR equivalent. The fix gets only the SYNR Pass staked for boost.