### PR TITLE
Fix unstake of SEED tokens when depositing sSYNR in the MainPool

### DIFF
--- a/contracts/SeedFactory.sol
+++ b/contracts/SeedFactory.sol
@@ -45,6 +45,7 @@ contract SeedFactory is PayloadUtils, WormholeTunnelUpgradeable {
       uint256 mainIndex,
       uint256 tokenAmountOrID
     ) = deserializeDeposit(payload);
+    require(tokenType != S_SYNR_SWAP, "SeedFarm: sSYNR swaps cannot be bridged back");
     require(tokenType < BLUEPRINT_STAKE_FOR_BOOST, "SeedFarm: blueprints' unstake does not require bridge");
     pool.unstakeViaFactory(_msgSender(), tokenType, lockedFrom, lockedUntil, mainIndex, tokenAmountOrID);
     return _wormholeTransferWithValue(payload, recipientChain, recipient, nonce, msg.value);

--- a/contracts/pool/SeedPool.sol
+++ b/contracts/pool/SeedPool.sol
@@ -49,7 +49,10 @@ contract SeedPool is SidePool {
 
   function unstake(uint256 depositIndex) external override {
     Deposit memory deposit = users[_msgSender()].deposits[depositIndex];
-    require(deposit.tokenType == BLUEPRINT_STAKE_FOR_BOOST, "SeedPool: invalid tokenType");
+    require(
+      deposit.lockedFrom > 0 && (deposit.tokenType == S_SYNR_SWAP || deposit.tokenType == BLUEPRINT_STAKE_FOR_BOOST),
+      "SeedPool: invalid tokenType"
+    );
     _unstakeDeposit(deposit);
   }
 

--- a/contracts/pool/SeedPool.sol
+++ b/contracts/pool/SeedPool.sol
@@ -49,10 +49,7 @@ contract SeedPool is SidePool {
 
   function unstake(uint256 depositIndex) external override {
     Deposit memory deposit = users[_msgSender()].deposits[depositIndex];
-    require(
-      deposit.lockedFrom > 0 && (deposit.tokenType == S_SYNR_SWAP || deposit.tokenType == BLUEPRINT_STAKE_FOR_BOOST),
-      "SeedPool: invalid tokenType"
-    );
+    require(deposit.tokenType == S_SYNR_SWAP || deposit.tokenType == BLUEPRINT_STAKE_FOR_BOOST, "SeedPool: invalid tokenType");
     _unstakeDeposit(deposit);
   }
 

--- a/contracts/pool/SidePool.sol
+++ b/contracts/pool/SidePool.sol
@@ -218,6 +218,9 @@ contract SidePool is PayloadUtils, ISidePool, TokenReceiver, Initializable, Owna
       return 0;
     }
     uint256 lockedUntil = uint256(deposit.lockedUntil);
+    if (uint256(deposit.lastRewardsAt) > lockedUntil) {
+      return 0;
+    }
     uint256 now_ = lockedUntil > timestamp ? timestamp : lockedUntil;
     return
       uint256(deposit.tokenAmount)
@@ -531,7 +534,7 @@ contract SidePool is PayloadUtils, ISidePool, TokenReceiver, Initializable, Owna
         uint256(deposit.tokenAmountOrID) == tokenAmountOrID,
       "SidePool: inconsistent deposit"
     );
-    if (tokenType == SYNR_STAKE || tokenType == SEED_SWAP) {
+    if (tokenType == SYNR_STAKE || tokenType == SEED_SWAP || tokenType == S_SYNR_SWAP) {
       uint256 vestedPercentage = getVestedPercentage(
         block.timestamp,
         uint256(deposit.lockedFrom),

--- a/contracts/utils/Constants.sol
+++ b/contracts/utils/Constants.sol
@@ -5,10 +5,10 @@ pragma solidity ^0.8.2;
 // (c) 2022+ SuperPower Labs Inc.
 
 contract Constants {
-  uint8 public constant S_SYNR_SWAP = 0;
-  uint8 public constant SYNR_STAKE = 1;
-  uint8 public constant SYNR_PASS_STAKE_FOR_BOOST = 2;
-  uint8 public constant SYNR_PASS_STAKE_FOR_SEEDS = 3;
-  uint8 public constant BLUEPRINT_STAKE_FOR_BOOST = 4;
-  uint8 public constant SEED_SWAP = 5;
+  uint8 public constant S_SYNR_SWAP = 1;
+  uint8 public constant SYNR_STAKE = 2;
+  uint8 public constant SYNR_PASS_STAKE_FOR_BOOST = 3;
+  uint8 public constant SYNR_PASS_STAKE_FOR_SEEDS = 4;
+  uint8 public constant BLUEPRINT_STAKE_FOR_BOOST = 5;
+  uint8 public constant SEED_SWAP = 6;
 }

--- a/test/Integration.test.js
+++ b/test/Integration.test.js
@@ -326,6 +326,14 @@ describe("#Integration test", function () {
       .emit(seedFactory, "DepositUnlocked")
       .withArgs(fundOwner.address, 0);
 
+    // unstake SEED from sSYNR
+
+    expect(await seed.balanceOf(user2.address)).equal("47255800000000000000000000");
+
+    await seedPool.connect(user2).unstake(0);
+
+    expect(await seed.balanceOf(user2.address)).equal("52255800000000000000000000");
+
     seedDeposit = await seedPool.getDepositByIndex(fundOwner.address, 0);
     expect(seedDeposit.tokenAmountOrID).equal(amount);
     expect(seedDeposit.unstakedAt).equal(ts + 1);

--- a/test/Integration.test.js
+++ b/test/Integration.test.js
@@ -136,21 +136,21 @@ describe("#Integration test", function () {
       365, // 1 year
       amount
     );
-    expect(payload).equal("1000000000000000000000036501");
+    expect(payload).equal("1000000000000000000000036502");
 
     let payload2 = await serializeInput(
       SYNR_STAKE, // SYNR
       150, // 1 year
       amount2
     );
-    expect(payload2).equal("2000000000000000000000015001");
+    expect(payload2).equal("2000000000000000000000015002");
 
     let payload3 = await serializeInput(
       S_SYNR_SWAP, // sSYNR
       0, // 1 year
       amount3
     );
-    expect(payload3).equal("500000000000000000000000000");
+    expect(payload3).equal("500000000000000000000000001");
 
     await synr.connect(fundOwner).approve(mainPool.address, ethers.utils.parseEther("35000"));
 
@@ -219,7 +219,7 @@ describe("#Integration test", function () {
 
     let deposit2 = await mainPool.getDepositByIndex(fundOwner.address, 1);
     expect(deposit2.tokenAmountOrID).equal(amount2);
-    expect(deposit2.tokenType).equal(1);
+    expect(deposit2.tokenType).equal(SYNR_STAKE);
     expect(deposit2.otherChain).equal(4);
     const finalPayload2 = await fromDepositToTransferPayload(deposit2);
 
@@ -278,7 +278,7 @@ describe("#Integration test", function () {
       0, // 1 year
       9
     );
-    expect(payload4).equal("900002");
+    expect(payload4).equal("900003");
 
     // approve the spending of the pass
     await pass.connect(fundOwner).approve(mainPool.address, 9);
@@ -358,7 +358,7 @@ describe("#Integration test", function () {
       amount
     );
 
-    expect(payload).equal("1000000000000000000000030001");
+    expect(payload).equal("1000000000000000000000030002");
 
     await synr.connect(user1).approve(mainPool.address, ethers.utils.parseEther("10000"));
 
@@ -419,7 +419,7 @@ describe("#Integration test", function () {
       amount
     );
 
-    expect(payload).equal("1000000000000000000000036501");
+    expect(payload).equal("1000000000000000000000036502");
 
     await synr.connect(fundOwner).approve(mainPool.address, ethers.utils.parseEther("10000"));
 

--- a/test/MainPool.test.js
+++ b/test/MainPool.test.js
@@ -2,7 +2,18 @@ const {expect, assert, use} = require("chai");
 
 const {serializeInput} = require("../scripts/lib/PayloadUtils");
 
-const {initEthers, assertThrowsMessage, getTimestamp, increaseBlockTimestampBy, bytes32Address, BNMulBy} = require("./helpers");
+const {
+  initEthers,
+  assertThrowsMessage,
+  getTimestamp,
+  increaseBlockTimestampBy,
+  bytes32Address,
+  BNMulBy,
+  SYNR_STAKE,
+  S_SYNR_SWAP,
+  SYNR_PASS_STAKE_FOR_BOOST,
+  SYNR_PASS_STAKE_FOR_SEEDS,
+} = require("./helpers");
 const {upgrades} = require("hardhat");
 
 // tests to be fixed
@@ -69,11 +80,11 @@ describe("#MainPool", function () {
       const amount = ethers.utils.parseEther("10000");
       await synr.connect(fundOwner).transferFrom(fundOwner.address, user1.address, amount);
       const payload = await serializeInput(
-        1, // SYNR
-        365, // 1 year
+        SYNR_STAKE, // SYNR
+        365, //  year
         amount
       );
-      expect(payload).equal("1000000000000000000000036501");
+      expect(payload).equal("1000000000000000000000036502");
       await synr.connect(user1).approve(mainPool.address, ethers.utils.parseEther("10000"));
       expect(await mainPool.connect(user1).stake(user1.address, payload, 4))
         .emit(mainPool, "DepositSaved")
@@ -101,7 +112,7 @@ describe("#MainPool", function () {
       const amount = ethers.utils.parseEther("10000");
       await synr.connect(fundOwner).transferFrom(fundOwner.address, user1.address, amount);
       const payload = await serializeInput(
-        1, // SYNR
+        SYNR_STAKE, // SYNR
         365, // 1 year
         amount
       );
@@ -135,7 +146,7 @@ describe("#MainPool", function () {
       const amount = ethers.utils.parseEther("10000");
       await synr.connect(fundOwner).transferFrom(fundOwner.address, user1.address, amount);
       const payload = await serializeInput(
-        1, // SYNR
+        SYNR_STAKE, // SYNR
         365, // 1 year
         amount
       );
@@ -169,7 +180,7 @@ describe("#MainPool", function () {
     it("should return length of deposits", async function () {
       const amount = ethers.utils.parseEther("10000");
       await synr.connect(fundOwner).transferFrom(fundOwner.address, user1.address, amount);
-      const payload = "100000000000000000000036501";
+      const payload = "100000000000000000000036502";
       await synr.connect(user1).approve(mainPool.address, ethers.utils.parseEther("10000"));
       expect(await mainPool.connect(user1).stake(user1.address, payload, 4))
         .emit(mainPool, "DepositSaved")
@@ -181,14 +192,14 @@ describe("#MainPool", function () {
     it("should return deposit by index", async function () {
       const amount = ethers.utils.parseEther("10000");
       await synr.connect(fundOwner).transferFrom(fundOwner.address, user1.address, amount);
-      const payload = "100000000000000000000036501";
+      const payload = "100000000000000000000036502";
       await synr.connect(user1).approve(mainPool.address, ethers.utils.parseEther("10000"));
       expect(await mainPool.connect(user1).stake(user1.address, payload, 4))
         .emit(mainPool, "DepositSaved")
         .withArgs(user1.address, 0);
       console.log(await mainPool.getDepositsLength(user1.address));
       const deposit = await mainPool.getDepositByIndex(user1.address, 0);
-      expect(parseInt(deposit)).equal(1, deposit.lockedFrom, deposit.lockedUntil, 0, amount);
+      expect(parseInt(deposit)).equal(SYNR_STAKE, deposit.lockedFrom, deposit.lockedUntil, 0, amount);
     });
   });
 

--- a/test/PayloadUtils.test.js
+++ b/test/PayloadUtils.test.js
@@ -2,7 +2,18 @@ const {expect, assert, use} = require("chai");
 
 const {fromDepositToTransferPayload, serializeInput} = require("../scripts/lib/PayloadUtils");
 
-const {initEthers, assertThrowsMessage, getTimestamp, increaseBlockTimestampBy, bytes32Address} = require("./helpers");
+const {
+  initEthers,
+  assertThrowsMessage,
+  getTimestamp,
+  increaseBlockTimestampBy,
+  bytes32Address,
+  S_SYNR_SWAP,
+  SYNR_STAKE,
+  SYNR_PASS_STAKE_FOR_BOOST,
+  SYNR_PASS_STAKE_FOR_SEEDS,
+  BLUEPRINT_STAKE_FOR_BOOST,
+} = require("./helpers");
 const {upgrades} = require("hardhat");
 
 // tests to be fixed
@@ -38,12 +49,12 @@ describe("#PayloadUtils", function () {
       const amount = ethers.utils.parseEther("10000");
 
       const payload = await serializeInput(
-        1, // SYNR
+        SYNR_STAKE, // SYNR
         365, // 1 year
         amount
       );
 
-      expect(payload).equal("1000000000000000000000036501");
+      expect(payload).equal("1000000000000000000000036502");
     });
 
     it("should throw invalid token", async function () {
@@ -80,13 +91,13 @@ describe("#PayloadUtils", function () {
       const amount = ethers.utils.parseEther("10000");
 
       const payload = await serializeInput(
-        2, // SYNR
+        SYNR_PASS_STAKE_FOR_BOOST, // SYNR
         365, // 1 year
         200
       );
       const deserialize = await payloadUtils.deserializeInput(payload);
 
-      expect(parseInt(deserialize)).equal(2, 365, amount);
+      expect(parseInt(deserialize)).equal(SYNR_PASS_STAKE_FOR_BOOST, 365, amount);
     });
 
     // TODO add a fake payload and verify if it fails
@@ -99,7 +110,7 @@ describe("#PayloadUtils", function () {
 
     it("should deserialize deposit", async function () {
       const deposit = {
-        tokenType: 2,
+        tokenType: SYNR_STAKE,
         lockedFrom: await getTimestamp(),
         lockedUntil: (await getTimestamp()) + 3600000,
         tokenAmountOrID: ethers.utils.parseEther("1000"),

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -38,11 +38,11 @@ const Helpers = {
   },
 };
 
-Helpers.S_SYNR_SWAP = 0;
-Helpers.SYNR_STAKE = 1;
-Helpers.SYNR_PASS_STAKE_FOR_BOOST = 2;
-Helpers.SYNR_PASS_STAKE_FOR_SEEDS = 3;
-Helpers.BLUEPRINT_STAKE_FOR_BOOST = 4;
-Helpers.SEED_SWAP = 5;
+Helpers.S_SYNR_SWAP = 1;
+Helpers.SYNR_STAKE = 2;
+Helpers.SYNR_PASS_STAKE_FOR_BOOST = 3;
+Helpers.SYNR_PASS_STAKE_FOR_SEEDS = 4;
+Helpers.BLUEPRINT_STAKE_FOR_BOOST = 5;
+Helpers.SEED_SWAP = 6;
 
 module.exports = Helpers;


### PR DESCRIPTION
DO NOT MERGE if CrediK does not approve it

1. The scenario in the title was not managed by the contract. In fact, the SEED staked in the SeedPool (in the side chain) after depositing sSYNR in the MainPool (in the main chain) were not unstakeable.

2. The original values of the constants in Constanst.sol had S_SYNR_SWAP = 0. But 0 is the default value for the `uint8` and it cannot be checked being sure that the deposit exists. So, when checking it, at least another property must be checked. For this reason, all the constant values have been shifter to start from 1.