### PR TITLE
Made side token approvable

### DIFF
--- a/contracts/pool/FarmingPool.sol
+++ b/contracts/pool/FarmingPool.sol
@@ -53,7 +53,7 @@ contract FarmingPool is SidePool {
    */
   function unstake(uint256 depositIndex) external override {
     Deposit memory deposit = users[_msgSender()].deposits[depositIndex];
-    require(deposit.tokenType == BLUEPRINT_STAKE_FOR_BOOST, "FarmingPool: only bluprints can be unstaked");
+    require(deposit.tokenType == BLUEPRINT_STAKE_FOR_BOOST, "FarmingPool: only blueprints can be unstaked");
     _unstakeDeposit(deposit);
   }
 

--- a/contracts/token/SideToken.sol
+++ b/contracts/token/SideToken.sol
@@ -8,6 +8,8 @@ import "@openzeppelin/contracts/access/AccessControl.sol";
 contract SideToken is ERC20, ERC20Burnable, AccessControl {
   bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
 
+  bool public allowancePaused = true;
+
   constructor(string memory name, string memory symbol) ERC20(name, symbol) {
     _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
   }
@@ -18,5 +20,17 @@ contract SideToken is ERC20, ERC20Burnable, AccessControl {
    */
   function mint(address to, uint256 amount) public onlyRole(MINTER_ROLE) {
     _mint(to, amount);
+  }
+
+  function unpauseAllowance() external onlyRole(DEFAULT_ADMIN_ROLE) {
+    // after un-pausing the allowance it cannot be paused again
+    allowancePaused = false;
+  }
+
+  function allowance(address owner, address spender) public view override returns (uint256) {
+    if (allowancePaused) {
+      return 0;
+    }
+    return super.allowance(owner, spender);
   }
 }

--- a/test/FarmingPool.test.js
+++ b/test/FarmingPool.test.js
@@ -197,11 +197,22 @@ describe("#FarmingPool", function () {
       await initAndDeploy(true);
     });
 
+    it("should revert is staking seed when allowance is paused", async function () {
+      const amount = ethers.utils.parseEther("1500000");
+      await seed.connect(user0).approve(pool.address, amount);
+      const balanceBefore = await seed.balanceOf(user0.address);
+      expect(balanceBefore).equal(normalize(user0sSeeds));
+
+      expect(pool.connect(user0).stake(SEED_SWAP, 0, amount)).revertedWith("ERC20: insufficient allowance");
+    });
+
     it("should stake some seed", async function () {
       const amount = ethers.utils.parseEther("1500000");
       await seed.connect(user0).approve(pool.address, amount);
       const balanceBefore = await seed.balanceOf(user0.address);
       expect(balanceBefore).equal(normalize(user0sSeeds));
+
+      await seed.unpauseAllowance();
 
       const lockedUntil = (await getTimestamp()) + 1 + 24 * 3600 * 10;
       expect(await pool.connect(user0).stake(SEED_SWAP, 0, amount))
@@ -212,6 +223,25 @@ describe("#FarmingPool", function () {
       expect(deposit.tokenAmountOrID).equal(amount);
       expect(deposit.tokenType).equal(SEED_SWAP);
       expect(deposit.lockedUntil).equal(lockedUntil);
+    });
+
+    it("should stake some seed and collect rewards", async function () {
+      const amount = ethers.utils.parseEther("1500000");
+      await seed.connect(user0).approve(pool.address, amount);
+      const balanceBefore = await seed.balanceOf(user0.address);
+      expect(balanceBefore).equal(normalize(user0sSeeds));
+
+      await seed.unpauseAllowance();
+
+      const lockedUntil = (await getTimestamp()) + 1 + 24 * 3600 * 10;
+      expect(await pool.connect(user0).stake(SEED_SWAP, 0, amount))
+        .emit(pool, "DepositSaved")
+        .withArgs(user0.address, 0);
+
+      await increaseBlockTimestampBy(50 * 24 * 3600);
+
+      await pool.connect(user0).collectRewards();
+      expect(await weed.balanceOf(user0.address)).equal("38840383561643835616438356");
     });
 
     it("should stake some blueprints", async function () {
@@ -257,8 +287,9 @@ describe("#FarmingPool", function () {
     it("should revert if unstake is not blueprint", async function () {
       const amount = ethers.utils.parseEther("1500000");
       await seed.connect(user0).approve(pool.address, amount);
+      await seed.unpauseAllowance();
       await pool.connect(user0).stake(SEED_SWAP, 0, amount);
-      await assertThrowsMessage(pool.connect(user0).unstake(0), "FarmingPool: only bluprints can be unstaked");
+      await assertThrowsMessage(pool.connect(user0).unstake(0), "FarmingPool: only blueprints can be unstaked");
     });
   });
 });

--- a/test/Integration.test.js
+++ b/test/Integration.test.js
@@ -244,6 +244,14 @@ describe("#Integration test", function () {
 
     expect(await seed.balanceOf(fundOwner.address)).equal("3500761035007610350");
 
+    await seed.connect(fundOwner).approve(operator.address, ethers.utils.parseEther("10"));
+    // seed token is locked
+    expect(await seed.allowance(fundOwner.address, operator.address)).equal(0);
+
+    await seed.unpauseAllowance();
+
+    expect(await seed.allowance(fundOwner.address, operator.address)).equal(ethers.utils.parseEther("10"));
+
     expect(await seedFactory.mockWormholeCompleteTransfer(user2.address, finalPayload3))
       .emit(seedFactory, "DepositSaved")
       .withArgs(user2.address, 0);

--- a/test/SeedPool.test.js
+++ b/test/SeedPool.test.js
@@ -215,7 +215,6 @@ describe("#SeedPool", function () {
       const balanceBefore = await seed.balanceOf(user0.address);
       expect(balanceBefore).equal(normalize(user0sSeeds));
 
-      const lockedUntil = (await getTimestamp()) + 1 + 24 * 3600 * 10;
       expect(pool.connect(user0).stake(SEED_SWAP, 0, amount)).revertedWith("SeedPool: unsupported token");
     });
   });


### PR DESCRIPTION
This limits the allowance for SideToken until the function `unpauseAllowance` is called.
Useful to set up an initial period during which the user cannot sell the tokens. Still, he can transfer them to other wallets.