### PR TITLE
Making priceRation an uint32

### DIFF
--- a/contracts/interfaces/ISidePool.sol
+++ b/contracts/interfaces/ISidePool.sol
@@ -56,7 +56,7 @@ interface ISidePool {
     uint32 stakeFactor;
     uint16 taxPoints; // ex 250 = 2.5%
     uint16 burnRatio;
-    uint16 priceRatio;
+    uint32 priceRatio;
     uint8 coolDownDays; // cool down period for
     uint8 status;
   }
@@ -95,7 +95,7 @@ interface ISidePool {
     uint8 coolDownDays_
   ) external;
 
-  function updatePriceRatio(uint16 priceRatio_) external;
+  function updatePriceRatio(uint32 priceRatio_) external;
 
   function updateOracle(address oracle_) external;
 

--- a/contracts/pool/SidePool.sol
+++ b/contracts/pool/SidePool.sol
@@ -120,7 +120,7 @@ contract SidePool is PayloadUtils, ISidePool, TokenReceiver, Initializable, Owna
   }
 
   // put to zero any parameter that remains the same
-  function updatePriceRatio(uint16 priceRatio_) external override {
+  function updatePriceRatio(uint32 priceRatio_) external override {
     require(conf.status == 1, "SidePool: not active");
     require(oracle != address(0) && _msgSender() == oracle, "SidePool: not the oracle");
     if (priceRatio_ > 0) {


### PR DESCRIPTION
With the current priceRatio if the ratio between SYNR and SEED changes more than 6 times, in favor of SEED, the uint16 will be insufficient. Moving it to uint32, we prevent the issue.