### PR TITLE
Disable approve instead of allowance

### DIFF
--- a/contracts/token/SideToken.sol
+++ b/contracts/token/SideToken.sol
@@ -27,10 +27,18 @@ contract SideToken is ERC20, ERC20Burnable, AccessControl {
     allowancePaused = false;
   }
 
-  function allowance(address owner, address spender) public view override returns (uint256) {
-    if (allowancePaused) {
-      return 0;
-    }
-    return super.allowance(owner, spender);
+  function approve(address spender, uint256 amount) public virtual override returns (bool) {
+    require(!allowancePaused, "SideToken: allowance not active");
+    return super.approve(spender, amount);
+  }
+
+  function increaseAllowance(address spender, uint256 addedValue) public virtual override returns (bool) {
+    require(!allowancePaused, "SideToken: allowance not active");
+    return super.increaseAllowance(spender, addedValue);
+  }
+
+  function decreaseAllowance(address spender, uint256 subtractedValue) public virtual override returns (bool) {
+    require(!allowancePaused, "SideToken: allowance not active");
+    return super.decreaseAllowance(spender, subtractedValue);
   }
 }

--- a/test/FarmingPool.test.js
+++ b/test/FarmingPool.test.js
@@ -200,20 +200,16 @@ describe("#FarmingPool", function () {
 
     it("should revert if staking seed when allowance is paused", async function () {
       const amount = ethers.utils.parseEther("1500000");
-      await seed.connect(user0).approve(pool.address, amount);
-      const balanceBefore = await seed.balanceOf(user0.address);
-      expect(balanceBefore).equal(normalize(user0sSeeds));
-
-      expect(pool.connect(user0).stake(SEED_SWAP, 0, amount)).revertedWith("ERC20: insufficient allowance");
+      expect(seed.connect(user0).approve(pool.address, amount)).revertedWith("SideToken: allowance not active");
     });
 
     it("should stake some seed", async function () {
       const amount = ethers.utils.parseEther("1500000");
+      await seed.unpauseAllowance();
+
       await seed.connect(user0).approve(pool.address, amount);
       const balanceBefore = await seed.balanceOf(user0.address);
       expect(balanceBefore).equal(normalize(user0sSeeds));
-
-      await seed.unpauseAllowance();
 
       const lockedUntil = (await getTimestamp()) + 1 + 24 * 3600 * 10;
       expect(await pool.connect(user0).stake(SEED_SWAP, 0, amount))
@@ -228,11 +224,10 @@ describe("#FarmingPool", function () {
 
     it("should stake some seed and collect rewards", async function () {
       const amount = ethers.utils.parseEther("1500000");
+      await seed.unpauseAllowance();
       await seed.connect(user0).approve(pool.address, amount);
       const balanceBefore = await seed.balanceOf(user0.address);
       expect(balanceBefore).equal(normalize(user0sSeeds));
-
-      await seed.unpauseAllowance();
 
       const lockedUntil = (await getTimestamp()) + 1 + 24 * 3600 * 10;
       expect(await pool.connect(user0).stake(SEED_SWAP, 0, amount))
@@ -287,8 +282,8 @@ describe("#FarmingPool", function () {
 
     it("should revert if unstake is not blueprint", async function () {
       const amount = ethers.utils.parseEther("1500000");
-      await seed.connect(user0).approve(pool.address, amount);
       await seed.unpauseAllowance();
+      await seed.connect(user0).approve(pool.address, amount);
       await pool.connect(user0).stake(SEED_SWAP, 0, amount);
       await assertThrowsMessage(pool.connect(user0).unstake(0), "FarmingPool: only blueprints can be unstaked");
     });

--- a/test/Integration.test.js
+++ b/test/Integration.test.js
@@ -253,11 +253,9 @@ describe("#Integration test", function () {
 
     expect(await seed.balanceOf(fundOwner.address)).equal("2917300862506341958");
 
-    await seed.connect(fundOwner).approve(operator.address, ethers.utils.parseEther("10"));
-    // seed token is locked
-    expect(await seed.allowance(fundOwner.address, operator.address)).equal(0);
-
     await seed.unpauseAllowance();
+
+    await seed.connect(fundOwner).approve(operator.address, ethers.utils.parseEther("10"));
 
     expect(await seed.allowance(fundOwner.address, operator.address)).equal(ethers.utils.parseEther("10"));
 

--- a/test/SeedPool.test.js
+++ b/test/SeedPool.test.js
@@ -212,6 +212,7 @@ describe("#SeedPool", function () {
 
     it("should revert unsupported token", async function () {
       const amount = ethers.utils.parseEther("1500000");
+      await seed.unpauseAllowance();
       await seed.connect(user0).approve(pool.address, amount);
       const balanceBefore = await seed.balanceOf(user0.address);
       expect(balanceBefore).equal(normalize(user0sSeeds));


### PR DESCRIPTION
Since the token starts with allowance paused, it is better to control the `approve` function (and increase and decrease) instead of the `approval` one. This way we save gas for the user that is not going to give an approve for a token that is not spendable.