### PR TITLE
Adding transfer on behalf of another user

### DIFF
--- a/contracts/Tesseract.sol
+++ b/contracts/Tesseract.sol
@@ -75,6 +75,7 @@ contract Tesseract is ITesseract, Initializable, PayloadUtilsUpgradeable, Ownabl
     uint32 nonce,
     bytes32 recipient
   ) external payable virtual override returns (uint64 sequence) {
+    require(getChainId() < 6, "Tesseract: not allowed on this chain");
     if (bridgeType == 1) {
       return IWormholeBridge(bridges[1]).wormholeTransfer(payload, recipientChain, recipient, nonce);
     } else {
@@ -82,5 +83,12 @@ contract Tesseract is ITesseract, Initializable, PayloadUtilsUpgradeable, Ownabl
     }
   }
 
+  function getChainId() public view returns (uint256) {
+    uint256 id;
+    assembly {
+      id := chainid()
+    }
+    return id;
+  }
   //  uint256[50] private __gap;
 }

--- a/contracts/Tesseract.sol
+++ b/contracts/Tesseract.sol
@@ -68,5 +68,19 @@ contract Tesseract is ITesseract, Initializable, PayloadUtilsUpgradeable, Ownabl
     }
   }
 
+  function crossChainTransferOnBehalf(
+    uint8 bridgeType,
+    uint256 payload,
+    uint16 recipientChain,
+    uint32 nonce,
+    bytes32 recipient
+  ) external payable virtual override returns (uint64 sequence) {
+    if (bridgeType == 1) {
+      return IWormholeBridge(bridges[1]).wormholeTransfer(payload, recipientChain, recipient, nonce);
+    } else {
+      revert("Tesseract: unsupported bridge");
+    }
+  }
+
   //  uint256[50] private __gap;
 }

--- a/contracts/bridge/SideWormholeBridge.sol
+++ b/contracts/bridge/SideWormholeBridge.sol
@@ -32,7 +32,7 @@ contract SideWormholeBridge is WormholeBridge {
       uint256 tokenAmountOrID
     ) = deserializeDeposit(payload);
     require(tokenType != S_SYNR_SWAP, "SideWormholeBridge: sSYNR swaps cannot be bridged back");
-    require(tokenType < BLUEPRINT_STAKE_FOR_BOOST, "SideWormholeBridge: blueprints' unstake does not require bridge");
+    require(tokenType < BLUEPRINT_STAKE_FOR_BOOST, "SideWormholeBridge: blueprints unstake does not require bridge");
     SeedPool(pool).unstakeViaBridge(sender, tokenType, lockedFrom, lockedUntil, mainIndex, tokenAmountOrID);
     uint64 sequence = _wormholeTransferWithValue(payload, recipientChain, recipient, nonce, msg.value);
     return sequence;

--- a/contracts/interfaces/ITesseract.sol
+++ b/contracts/interfaces/ITesseract.sol
@@ -17,4 +17,12 @@ interface ITesseract {
   ) external payable returns (uint64 sequence);
 
   function completeCrossChainTransfer(uint16 bridgeType, bytes memory encodedVm) external;
+
+  function crossChainTransferOnBehalf(
+    uint8 bridgeType,
+    uint256 payload,
+    uint16 recipientChain,
+    uint32 nonce,
+    bytes32 recipient
+  ) external payable returns (uint64 sequence);
 }

--- a/test/FarmingPool.test.js
+++ b/test/FarmingPool.test.js
@@ -265,6 +265,8 @@ describe("#FarmingPool", function () {
       expect(await pool.connect(user0).unstake(deposit))
         .emit(pool, "DepositUnlocked")
         .withArgs(user0.address, 0);
+      deposit = await pool.getDepositByIndex(user0.address, 0);
+      assert.isTrue(deposit.unlockedAt !== 0);
     });
 
     it("should revert if unstake is not blueprint", async function () {

--- a/test/Integration.test.js
+++ b/test/Integration.test.js
@@ -171,6 +171,16 @@ describe("#Integration test", function () {
     await synr.connect(fundOwner).approve(mainPool.address, ethers.utils.parseEther("35000"));
 
     expect(
+      mainTesseract.connect(fundOwner).crossChainTransferOnBehalf(
+        1,
+        payload,
+        4, // BSC
+        1,
+        user1.address
+      )
+    ).revertedWith("Tesseract: not allowed on this chain");
+
+    expect(
       await mainTesseract.connect(fundOwner).crossChainTransfer(
         1,
         payload,


### PR DESCRIPTION
This adds a function that allows a third party to start the cross chain transfer on behalf of a user. It can be used by a contract locking assets, in order to unlock the asset just in order to stake it in the seed farm.