### PR TITLE
Fix rewards calculation

### DIFF
--- a/contracts/bridge/MainWormholeBridge.sol
+++ b/contracts/bridge/MainWormholeBridge.sol
@@ -43,7 +43,6 @@ contract MainWormholeBridge is WormholeBridge {
       uint256 mainIndex,
       uint256 tokenAmountOrID
     ) = deserializeDeposit(payload);
-    require(tokenType > S_SYNR_SWAP, "MainWormholeBridge: sSYNR can't be unstaked");
     MainPool(pool).unstake(to, tokenType, lockedFrom, lockedUntil, mainIndex, tokenAmountOrID);
   }
 
@@ -64,7 +63,6 @@ is correct.
     uint256 tokenAmountOrID,
     bytes memory signature
   ) external override {
-    require(tokenType > S_SYNR_SWAP, "MainWormholeBridge: sSYNR can't be unstaked");
     require(
       isSignedByValidator(encodeForSignature(to, tokenType, lockedFrom, lockedUntil, mainIndex, tokenAmountOrID), signature),
       "MainWormholeBridge: invalid signature"

--- a/contracts/bridge/SideWormholeBridge.sol
+++ b/contracts/bridge/SideWormholeBridge.sol
@@ -50,7 +50,6 @@ contract SideWormholeBridge is WormholeBridge {
       uint256 mainIndex,
       uint256 tokenAmountOrID
     ) = deserializeDeposit(payload);
-    require(tokenType < BLUEPRINT_STAKE_FOR_BOOST, "SideWormholeBridge: no blueprint allowed here");
     SeedPool(pool).stakeViaBridge(to, tokenType, lockedFrom, lockedUntil, mainIndex, tokenAmountOrID);
   }
 
@@ -71,7 +70,6 @@ that assures that the data are correct.
     uint256 tokenAmountOrID,
     bytes memory signature
   ) external override {
-    require(tokenType < BLUEPRINT_STAKE_FOR_BOOST, "SideWormholeBridge: no blueprint allowed here");
     require(
       isSignedByValidator(encodeForSignature(to, tokenType, lockedFrom, lockedUntil, mainIndex, tokenAmountOrID), signature),
       "SideWormholeBridge: invalid signature"

--- a/contracts/pool/SidePool.sol
+++ b/contracts/pool/SidePool.sol
@@ -16,7 +16,7 @@ import "../token/SideToken.sol";
 import "../interfaces/IERC721Minimal.sol";
 import "../interfaces/ISidePoolViews.sol";
 
-import "hardhat/console.sol";
+//import "hardhat/console.sol";
 
 abstract contract SidePool is
   PayloadUtilsUpgradeable,
@@ -230,7 +230,7 @@ abstract contract SidePool is
     uint256 nftAmount,
     uint256 limit,
     uint256 factor
-  ) internal view returns (uint256, uint256) {
+  ) internal pure returns (uint256, uint256) {
     limit = uint256(nftAmount).mul(limit).mul(1e18);
     if (limit < amount) {
       amount = limit;

--- a/contracts/pool/SidePoolViews.sol
+++ b/contracts/pool/SidePoolViews.sol
@@ -42,17 +42,22 @@ contract SidePoolViews is ISidePoolViews, Constants, Initializable, OwnableUpgra
     uint256 timestamp,
     uint256 lastRewardsAt
   ) public view override returns (uint256) {
-    if (
-      deposit.tokenType == S_SYNR_SWAP ||
-      deposit.generator == 0 ||
-      deposit.unlockedAt != 0 ||
-      lastRewardsAt >= deposit.lockedUntil
-    ) {
+    if (deposit.tokenType == S_SYNR_SWAP || deposit.generator == 0 || deposit.unlockedAt != 0) {
       return 0;
     }
-    if (timestamp > deposit.lockedUntil) {
-      timestamp = deposit.lockedUntil;
-    }
+    // The following version can be used if we prefer not to allow the user
+    // to continue to get rewards, after the lockup time is passed:
+    //    if (
+    //      deposit.tokenType == S_SYNR_SWAP ||
+    //      deposit.generator == 0 ||
+    //      deposit.unlockedAt != 0 ||
+    //      lastRewardsAt >= deposit.lockedUntil
+    //    ) {
+    //      return 0;
+    //    }
+    //    if (timestamp > deposit.lockedUntil) {
+    //      timestamp = deposit.lockedUntil;
+    //    }
     return
       uint256(deposit.generator)
         .mul(deposit.rewardsFactor)

--- a/test/Integration.test.js
+++ b/test/Integration.test.js
@@ -627,8 +627,8 @@ describe("#Integration test", function () {
     let balanceBob = await seed.balanceOf(bob.address);
     let balanceFred = await seed.balanceOf(fred.address);
 
-    expect(getInt(balanceBob)).equal(1657839);
-    expect(getInt(balanceFred)).equal(1657839);
+    expect(getInt(balanceBob)).equal(1657841);
+    expect(getInt(balanceFred)).equal(1657840);
 
     await unstake(bob, 0);
     for (let i = 0; i < 10; i++) {
@@ -638,9 +638,9 @@ describe("#Integration test", function () {
     balanceBob = await seed.balanceOf(bob.address);
     balanceFred = await seed.balanceOf(fred.address);
 
-    expect(getInt(balanceBob)).equal(1657839);
+    expect(getInt(balanceBob)).equal(1657841);
     // this is just 1 more that
-    expect(getInt(balanceFred)).equal(1657839);
+    expect(getInt(balanceFred)).equal(1657841);
   });
 
   it("should verify final SEED for many lockup times", async function () {
@@ -657,17 +657,18 @@ describe("#Integration test", function () {
     expect(getInt(user.deposits[0].generator)).equal(530000);
 
     let rewards0 = await pendingRewards(conf2, user, await getTimestamp());
+    let rewards = await seedPool.pendingRewards(bob.address);
+    expect(getInt(rewards)).equal(getInt(rewards0));
 
-    // be sure that being late does not produces more rewards
+    // not unstaking will produce more rewards
     await increaseBlockTimestampBy(lockupTime * 24 * 3600);
 
-    let rewards = await seedPool.pendingRewards(bob.address);
-    expect(rewards).equal(rewards0);
+    rewards = await seedPool.pendingRewards(bob.address);
     // const ratioRewardsGenerator =
-    expect(rewards).equal("16200703634995814307458");
+    expect(getInt(rewards)).equal(32401);
 
     await unstake(bob);
-    expect(await seed.balanceOf(bob.address)).equal(rewards);
+    expect(getInt(await seed.balanceOf(bob.address))).equal(getInt(rewards));
 
     await initAndDeploy(true);
 
@@ -676,10 +677,10 @@ describe("#Integration test", function () {
     await stake(bob, amount, 0, undefined, lockupTime);
     await increaseBlockTimestampBy(lockupTime * 24 * 3600);
     await unstake(bob);
-    expect(await seed.balanceOf(bob.address)).equal("416030142937172374429224");
+    expect(getInt(await seed.balanceOf(bob.address))).equal(416030);
   });
 
-  it("should verify that it does not get rewards after lockup time has passed", async function () {
+  it("should verify that it does get rewards after lockup time has passed", async function () {
     const amount = ethers.utils.parseEther("10000");
 
     await stakeSYNR(bob, amount.mul(10));
@@ -688,13 +689,13 @@ describe("#Integration test", function () {
 
     await seedPool.connect(bob).collectRewards();
     let balanceBob = await seed.balanceOf(bob.address);
-    expect(getInt(balanceBob)).equal(1657839);
+    expect(getInt(balanceBob)).equal(1657840);
 
     await increaseBlockTimestampBy(365 * 24 * 3600);
 
     await seedPool.connect(bob).collectRewards();
     balanceBob = await seed.balanceOf(bob.address);
-    expect(getInt(balanceBob)).equal(1657839);
+    expect(getInt(balanceBob)).equal(1657840 * 2);
 
     await initAndDeploy(true);
 
@@ -717,7 +718,7 @@ describe("#Integration test", function () {
 
     balanceBob = await seed.balanceOf(bob.address);
 
-    expect(getInt(balanceBob)).equal(1657839);
+    expect(getInt(balanceBob)).equal(1953071);
   });
 
   it("should verify SYNR and SYNR equivalent produce same results", async function () {
@@ -840,7 +841,7 @@ describe("#Integration test", function () {
 
     unboosted = await seed.balanceOf(fundOwner.address);
 
-    expect(unboosted).equal(rewards0);
+    expect(getInt(unboosted)).equal(getInt(rewards0));
 
     await initAndDeploy();
 

--- a/test/SidePoolViews.test.js
+++ b/test/SidePoolViews.test.js
@@ -261,20 +261,9 @@ describe("#SidePoolViews", function () {
       expect(ratio).equal(expected[j + 1]);
     }
 
-    // now with rewards after 2 years. Results should not change
-    for (let i = conf.minimumLockupTime, j = 0; i < conf.maximumLockupTime; i += 7, j += 2) {
-      let deposit = getDeposit(tokenTypes.SYNR_STAKE, timestamp, timestamp + i * DAY, amount);
-      let rewards = calculateUntaxedRewards(conf, deposit, timestamp + 666 * DAY, timestamp);
-      expect(getInt(rewards)).equal(expected[j]);
-      let ratio = parseInt((100 * getInt(rewards)) / getInt(deposit.generator));
-      expect(ratio).equal(expected[j + 1]);
-    }
-
-    // now checking that rewards after lockupTime are zero
-    for (let i = conf.minimumLockupTime, j = 0; i < conf.maximumLockupTime; i += 7, j += 2) {
-      let deposit = getDeposit(tokenTypes.SYNR_STAKE, timestamp, timestamp + i * DAY, amount);
-      let rewards = calculateUntaxedRewards(conf, deposit, timestamp + i * DAY, timestamp + i * DAY);
-      expect(getInt(rewards)).equal(0);
-    }
+    // now with rewards after 2 years. Results should be equal
+    let deposit = getDeposit(tokenTypes.SYNR_STAKE, timestamp, timestamp + conf.minimumLockupTime * DAY, amount);
+    let rewards = calculateUntaxedRewards(conf, deposit, timestamp + 666 * DAY, timestamp);
+    expect(getInt(rewards)).equal(2148400);
   });
 });

--- a/test/SidePoolViews.test.js
+++ b/test/SidePoolViews.test.js
@@ -1,8 +1,9 @@
 const {expect} = require("chai");
-const {BN} = require("./helpers/utils");
-const {boostRewards} = require("./helpers/sidePoolViews");
+const {BN, DAY} = require("./helpers/utils");
+const {boostRewards, calculateUntaxedRewards} = require("./helpers/sidePoolViews");
+const {getStakedAndLockedAmount} = require("./helpers/sidePool");
 
-const {initEthers} = require("../test/helpers");
+const {initEthers, tokenTypes, getTimestamp, getInt} = require("../test/helpers");
 const {upgrades} = require("hardhat");
 
 describe("#SidePoolViews", function () {
@@ -192,6 +193,88 @@ describe("#SidePoolViews", function () {
         blueprintAmountForBoost
       );
       expect(boostedRewards).equal("10814400000000000000000000");
+    }
+  });
+
+  function getConf() {
+    return {
+      rewardsFactor: 17000,
+      decayInterval: 604800,
+      decayFactor: 9900,
+      minimumLockupTime: 112,
+      maximumLockupTime: 365,
+      poolInitAt: 1654720653,
+      lastRatioUpdateAt: 1654720653,
+      swapFactor: 2000,
+      stakeFactor: 530,
+      taxPoints: 800,
+      coolDownDays: 14,
+      status: 1,
+      blueprintAmount: 0,
+      sPSynrEquivalent: 100000,
+      sPBoostFactor: 13220,
+      sPBoostLimit: 200000,
+      bPSynrEquivalent: 3000,
+      bPBoostFactor: 13220,
+      bPBoostLimit: 6000,
+      priceRatio: 10000,
+    };
+  }
+
+  function getDeposit(tokenType, lockedFrom, lockedUntil, stakedAmount) {
+    const conf = getConf();
+    return {
+      tokenType,
+      lockedFrom,
+      lockedUntil,
+      stakedAmount: BN(stakedAmount),
+      tokenID: 0,
+      unlockedAt: 0,
+      mainIndex: 0,
+      generator: getStakedAndLockedAmount(conf, conf, tokenType, stakedAmount),
+      rewardsFactor: 17000,
+      extra1: 0,
+      extra2: 0,
+      extra3: 0,
+      extra4: 0,
+    };
+  }
+
+  it("should verify that the rewards are correct", async function () {
+    let conf = getConf();
+    let amount = BN(100000, 18);
+    const expected = [
+      361292, 68, 389513, 73, 418397, 78, 447912, 84, 478122, 90, 508995, 96, 540532, 101, 572692, 108, 605554, 114, 639080,
+      120, 673269, 127, 708122, 133, 743590, 140, 779768, 147, 816609, 154, 854114, 161, 892227, 168, 931058, 175, 970552, 183,
+      1010709, 190, 1051530, 198, 1092951, 206, 1135097, 214, 1177907, 222, 1221380, 230, 1265517, 238, 1310245, 247, 1355707,
+      255, 1401833, 264, 1448622, 273, 1495996, 282, 1544110, 291, 1592889, 300, 1642330, 309, 1692435, 319, 1743116, 328,
+      1794547, 338,
+    ];
+
+    let timestamp = await getTimestamp();
+
+    for (let i = conf.minimumLockupTime, j = 0; i < conf.maximumLockupTime; i += 7, j += 2) {
+      let deposit = getDeposit(tokenTypes.SYNR_STAKE, timestamp, timestamp + i * DAY, amount);
+      let rewards = calculateUntaxedRewards(conf, deposit, timestamp + i * DAY, timestamp);
+      expect(getInt(rewards)).equal(expected[j]);
+      let ratio = parseInt((100 * getInt(rewards)) / getInt(deposit.generator));
+      expect(ratio).equal(expected[j + 1]);
+    }
+
+    // now with rewards after 2 years. Results should not change
+    for (let i = conf.minimumLockupTime, j = 0; i < conf.maximumLockupTime; i += 7, j += 2) {
+      let deposit = getDeposit(tokenTypes.SYNR_STAKE, timestamp, timestamp + i * DAY, amount);
+      let rewards = calculateUntaxedRewards(conf, deposit, timestamp + 666 * DAY, timestamp);
+      expect(getInt(rewards)).equal(expected[j]);
+      let ratio = parseInt((100 * getInt(rewards)) / getInt(deposit.generator));
+      expect(ratio).equal(expected[j + 1]);
+    }
+
+    // now checking that rewards after lockupTime are zero
+    for (let i = conf.minimumLockupTime, j = 0; i < conf.maximumLockupTime; i += 7, j += 2) {
+      let deposit = getDeposit(tokenTypes.SYNR_STAKE, timestamp, timestamp + i * DAY, amount);
+      let rewards = calculateUntaxedRewards(conf, deposit, timestamp + i * DAY, timestamp + i * DAY);
+      expect(getInt(rewards)).equal(0);
     }
   });
 });

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -66,6 +66,10 @@ const Helpers = {
     b = ethers.utils.formatEther(b.toString()).split(".")[0];
     expect(a).equal(b);
   },
+
+  getInt(val) {
+    return parseInt(ethers.utils.formatEther(val.toString()));
+  },
 };
 
 Helpers.tokenTypes = {

--- a/test/helpers/sidePool.js
+++ b/test/helpers/sidePool.js
@@ -52,10 +52,37 @@ function canUnstakeWithoutTax(deposit, blockTimestamp) {
   return deposit.lockedUntil > 0 && blockTimestamp > deposit.lockedUntil;
 }
 
+function calculateTokenAmount(conf, extraConf, amount, tokenType) {
+  return BN(amount)
+    .mul(tokenType === tokenTypes.S_SYNR_SWAP ? conf.swapFactor : conf.stakeFactor)
+    .mul(extraConf.priceRatio)
+    .div(1000000);
+}
+
+function getStakedAndLockedAmount(conf, extraConf, tokenType, tokenAmountOrID) {
+  let stakedAmount = BN();
+  let generator = BN();
+  if (tokenType === tokenTypes.S_SYNR_SWAP) {
+    generator = calculateTokenAmount(conf, extraConf, tokenAmountOrID, tokenType);
+  } else if (tokenType === tokenTypes.SYNR_STAKE) {
+    generator = calculateTokenAmount(conf, extraConf, tokenAmountOrID, tokenType);
+    stakedAmount = BN(tokenAmountOrID);
+  } else if (tokenType === tokenTypes.SYNR_PASS_STAKE_FOR_SEEDS) {
+    stakedAmount = BN(extraConf.sPSynrEquivalent).mul(1e18);
+    generator = calculateTokenAmount(conf, extraConf, stakedAmount, tokenType);
+  } else if (tokenType === tokenTypes.BLUEPRINT_STAKE_FOR_SEEDS) {
+    stakedAmount = BN(extraConf.bPSynrEquivalent).mul(1e18);
+    generator = calculateTokenAmount(conf, extraConf, stakedAmount, tokenType);
+  }
+  return stakedAmount, generator;
+}
+
 function getGenerator(synrAmount) {}
 
 module.exports = {
   pendingRewards,
   untaxedPendingRewards,
   canUnstakeWithoutTax,
+  getStakedAndLockedAmount,
+  calculateTokenAmount,
 };

--- a/test/helpers/sidePoolViews.js
+++ b/test/helpers/sidePoolViews.js
@@ -87,8 +87,16 @@ function getLockupTime(deposit) {
 }
 
 function calculateUntaxedRewards(conf, deposit, timestamp, lastRewardsAt) {
-  if (deposit.generator === 0 || deposit.tokenType === tokenTypes.S_SYNR_SWAP || deposit.unlockedAt !== 0) {
+  if (
+    deposit.generator === 0 ||
+    deposit.tokenType === tokenTypes.S_SYNR_SWAP ||
+    deposit.unlockedAt !== 0 ||
+    BN(lastRewardsAt).gte(deposit.lockedUntil)
+  ) {
     return 0;
+  }
+  if (timestamp > deposit.lockedUntil) {
+    timestamp = deposit.lockedUntil;
   }
   return BN(deposit.generator)
     .mul(deposit.rewardsFactor)

--- a/test/helpers/sidePoolViews.js
+++ b/test/helpers/sidePoolViews.js
@@ -87,16 +87,8 @@ function getLockupTime(deposit) {
 }
 
 function calculateUntaxedRewards(conf, deposit, timestamp, lastRewardsAt) {
-  if (
-    deposit.generator === 0 ||
-    deposit.tokenType === tokenTypes.S_SYNR_SWAP ||
-    deposit.unlockedAt !== 0 ||
-    BN(lastRewardsAt).gte(deposit.lockedUntil)
-  ) {
+  if (deposit.generator === 0 || deposit.tokenType === tokenTypes.S_SYNR_SWAP || deposit.unlockedAt !== 0) {
     return 0;
-  }
-  if (timestamp > deposit.lockedUntil) {
-    timestamp = deposit.lockedUntil;
   }
   return BN(deposit.generator)
     .mul(deposit.rewardsFactor)


### PR DESCRIPTION
In a previous commit, I mistakenly fix a function introducing a bug. I just changed it back, fixing what actually was causing the original problem, i.e., trying to get rewards after the lockup time has passed and getting more than expected.

I commented some code that can be used to limit the rewards after the lockupTime passes in case we think it is better than the user unstakes and stakes again.

I also removed some require in the bridges that are responsibility of the pools, and are actually checked by the pools.

Finally, I removed some console statement, changed some view to pure and done some other little adjustment.