### PR TITLE
Use block.chainid instead of using assembly to get the chain ID

### DIFF
--- a/contracts/bridge/WormholeBridge.sol
+++ b/contracts/bridge/WormholeBridge.sol
@@ -95,7 +95,7 @@ contract WormholeBridge is PayloadUtils, WormholeTunnelUpgradeable {
       keccak256(
         abi.encodePacked(
           "\x19\x01", // EIP-191
-          getChainId(),
+          block.chainid,
           to,
           tokenType,
           lockedFrom,
@@ -104,13 +104,5 @@ contract WormholeBridge is PayloadUtils, WormholeTunnelUpgradeable {
           tokenAmountOrID
         )
       );
-  }
-
-  function getChainId() public view returns (uint256) {
-    uint256 id;
-    assembly {
-      id := chainid()
-    }
-    return id;
   }
 }


### PR DESCRIPTION
Fix WBC-02, using `block.chainid` (introduced in Solidity 0.8) instread of using assembly to get the chain ID in the function to hash the data to be signed in the WormholeBridge in the emergency function.